### PR TITLE
Improve dirs output and add -c option

### DIFF
--- a/share/functions/dirs.fish
+++ b/share/functions/dirs.fish
@@ -1,9 +1,18 @@
-function dirs --description "Print directory stack"
-	echo -n (command pwd)"  "
-	for i in $dirstack
-		echo -n $i"  "
-	end
-	echo
+function dirs --description 'Print directory stack'
+        # process options
+        if count $argv >/dev/null
+                switch $argv[1]
+                        case -c
+                                # clear directory stack
+                                set -e -g dirstack
+				return 0
+		end
+        end
+
+        # replace $HOME with ~
+        echo -n (echo (command pwd) | sed -e "s|^$HOME|~|")"  "
+        for i in $dirstack
+                echo -n (echo $i | sed -e "s|^$HOME|~|")"  "
+        end
+        echo
 end
-
-


### PR DESCRIPTION
Adds behaviour similar to bash:
- shorten dirs output by representing $HOME as ~;
- provide a '-c' option to clear the stack
